### PR TITLE
Another fix for e (end of word)

### DIFF
--- a/src/vibreoffice.vbs
+++ b/src/vibreoffice.vbs
@@ -413,8 +413,8 @@ Function ProcessStandardMovementKey(oEvent)
         ProcessMovementKey("l", True)
     ElseIf c = 1028 Then
         ProcessMovementKey("^", True)
-	ElseIf c = "0" Then
-		ProcessMovementKey("0", True) ' key for zero (0)
+    ElseIf c = "0" Then
+        ProcessMovementKey("0", True) ' key for zero (0)
     ElseIf c = 1029 Then
         ProcessMovementKey("$", True)
     Else
@@ -983,6 +983,13 @@ Function ProcessMovementKey(keyChar, Optional bExpand, Optional keyModifiers)
             oTextCursor.gotoNextWord(bExpand)
         End If
         oTextCursor.gotoEndOfWord(bExpand)
+
+        ' This is needed in case the current line has no words.
+        ' This way it will go to the next line (if it exists).
+        If NOT oTextCursor.isEndofWord(bExpand) Then
+            oTextCursor.gotoNextWord(bExpand)
+            oTextCursor.gotoEndofWord(bExpand)
+        End If
 
     ElseIf keyChar = ")" Then
         oTextCursor.gotoNextSentence(bExpand)


### PR DESCRIPTION
"e" can now go to the next line when there are only whitespace characters on the current line. Before this the cursor would get stuck, not moving no matter how many times you press "e" when the current line only had whitespace characters.